### PR TITLE
Fix issue #33

### DIFF
--- a/discord/installer/install_windows.bat
+++ b/discord/installer/install_windows.bat
@@ -1,7 +1,5 @@
 @echo off
 REM Just run a powershell command.
-SET ScriptDir=%~dp0
-Set ScriptLocation=%ScriptDir%win_ps.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%ScriptLocation%'"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0%win_ps.ps1'"
 pause
 

--- a/discord/installer/install_windows_PTB.bat
+++ b/discord/installer/install_windows_PTB.bat
@@ -1,7 +1,5 @@
 @echo off
 REM Just run a powershell command.
-SET ScriptDir=%~dp0
-Set ScriptLocation=%ScriptDir%win_ps.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%ScriptLocation%' -isPTB"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0%win_ps.ps1' -isPTB"
 pause
 


### PR DESCRIPTION
Issue #33: Windows installer breaks if path to installer has `&` in
it.
The fix is to use %~dp0 within quotes.
