### PR TITLE
Reach text input field with CSS selector query

### DIFF
--- a/discord/addon/core/core.js
+++ b/discord/addon/core/core.js
@@ -19,11 +19,13 @@ cssMap['/extracss-pure.css'] = require('raw-loader!./extracss-pure.css');
 cssMap['/extracss-webkit.css'] = require('raw-loader!./extracss-webkit.css');
 
 function getChatInputTextarea() {
-    var sendbox = utils.getElementsByClassName('channel-text-area-default');
+    var sendbox = document.querySelector('.channel-text-area-default > [class*=inner] > textarea');
     if(sendbox.length === 0) {
         return null;
     }
-    return utils.htmlCollectionToArray(sendbox[0].getElementsByTagName('textarea'))[0];
+    else {
+        return sendbox ;
+    }
 }
 
 window.addEventListener('bpm_backend_message', function(event) {


### PR DESCRIPTION
Alternative way to find the node of the user input text field, with a fancy CSS selector by @ByzantineFailure .

Implementation of #81 proposal for a selector-based fetching.